### PR TITLE
db 3

### DIFF
--- a/db-mysql/fiscales_db.sql
+++ b/db-mysql/fiscales_db.sql
@@ -11,6 +11,7 @@ SET time_zone = "+00:00";
 --
 -- Base de datos: `fiscales_db`
 --
+
 -- -----------------------
 -- Usuario
 -- -----------------------
@@ -120,8 +121,8 @@ CREATE TABLE `gen_distrito` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-	-- Existen distintos modelos entre provincias / BsAs,Mza,Tucuman / CABA en la seccion, pero unificamos todo en seccion para mantener la estructura estandar
-	-- -----------------------
+  -- Existen distintos modelos entre provincias / BsAs,Mza,Tucuman / CABA en la seccion, pero unificamos todo en seccion para mantener la estructura estandar
+  -- -----------------------
 CREATE TABLE `gen_seccion` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `distrito_id` int(11) NOT NULL,
@@ -255,6 +256,7 @@ CREATE TABLE `fis_centro_computo` (
   `seccion_id` int(11) DEFAULT NULL,
   `distrito_id` int(11) DEFAULT NULL,
   `telefono_recepcion_imagen` varchar(45) DEFAULT NULL,
+  `telefono_recepcion_denuncia` varchar(45) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `centrocomputo_responsable_idx` (`reponsable_user_id`),
   KEY `centrocomputo_circuito_idx` (`circuito_id`),
@@ -306,7 +308,6 @@ CREATE TABLE `fis_centro_computo_auditoria` (
   CONSTRAINT `centrocomputoauditoria_estadocorreoacta` FOREIGN KEY (`acta_correo_estado_id`) REFERENCES `fis_centro_computo_auditoria_acta_correo_estado` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   CONSTRAINT `centrocomputoauditoria_mesaid` FOREIGN KEY (`mesa_id`) REFERENCES `gen_mesa` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
 
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/db-mysql/fiscales_db.sql
+++ b/db-mysql/fiscales_db.sql
@@ -161,7 +161,7 @@ CREATE TABLE `gen_mesa` (
 -- -----------------------
 -- Comicio
 -- -----------------------
-
+/*
 CREATE TABLE `com_comicio_estado` (
   `id` INT NOT NULL,
   `descripcion` VARCHAR(45) NULL,
@@ -205,6 +205,82 @@ CREATE TABLE `com_comisio_candidato` (
   CONSTRAINT `comiciocandidato_comiciocategoria` FOREIGN KEY (`comicio_categoria_id`) REFERENCES `com_comicio_categoria` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   CONSTRAINT `comiciocandidato_comiciofuerzapolitica` FOREIGN KEY (`comicio_fuerza_politica_id`) REFERENCES `com_comicio_fuerza_politica` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+*/
+-- -----------------------
+-- fiscalizcion
+-- -----------------------
+
+CREATE TABLE `fis_fiscalizacion_estado` (
+  `id` int(11) NOT NULL,
+  `descripcion` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `fis_fiscalizacion` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `estado_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fiscalizacion_estado_idx` (`estado_id`),
+  CONSTRAINT `fiscalizacion_estado` FOREIGN KEY (`estado_id`) REFERENCES `fis_fiscalizacion_estado` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `fis_fiscalizacion_mesa_estado` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `descripcion` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `fis_fiscalizacion_mesa` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `fiscalizacion_id` int(11) NOT NULL,
+  `mesa_id` int(11) NOT NULL,
+  `votos_massarasa` int(11) DEFAULT NULL,
+  `votos_milei` int(11) DEFAULT NULL,
+  `votos_blanco` int(11) DEFAULT NULL,
+  `votos_nulos` int(11) DEFAULT NULL,
+  `votos_impugnados_massarasa` int(11) DEFAULT NULL,
+  `votos_impugnados_milei` int(11) DEFAULT NULL,
+  `estado_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fiscalizacionmesa_estado_idx` (`estado_id`),
+  KEY `fiscalizacionmesa_fiscalizacion_idx` (`fiscalizacion_id`),
+  KEY `fiscalizacionmesa_mesa_idx` (`mesa_id`),
+  CONSTRAINT `fiscalizacionmesa_estado` FOREIGN KEY (`estado_id`) REFERENCES `fis_fiscalizacion_mesa_estado` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `fiscalizacionmesa_fiscalizacion` FOREIGN KEY (`fiscalizacion_id`) REFERENCES `fis_fiscalizacion` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `fiscalizacionmesa_mesa` FOREIGN KEY (`mesa_id`) REFERENCES `gen_mesa` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `fis_fiscal_mesa` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `fiscalizacion_mesa_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fiscalmesa_user_idx` (`user_id`),
+  KEY `fiscalmesa_fiscalizacionmesa_idx` (`fiscalizacion_mesa_id`),
+  CONSTRAINT `fiscalmesa_fiscalizacionmesa` FOREIGN KEY (`fiscalizacion_mesa_id`) REFERENCES `fis_fiscalizacion_mesa` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `fiscalmesa_user` FOREIGN KEY (`user_id`) REFERENCES `gen_user` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `fis_fiscal_general` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `gen_local_comicio` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fiscalgeneral_user_idx` (`user_id`),
+  KEY `fiscalgeneral_localcomicio_idx` (`gen_local_comicio`),
+  CONSTRAINT `fiscalgeneral_localcomicio` FOREIGN KEY (`gen_local_comicio`) REFERENCES `gen_local_comicio` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `fiscalgeneral_user` FOREIGN KEY (`user_id`) REFERENCES `gen_user` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `fis_coordinador` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `circuito_id` int(11) DEFAULT NULL,
+  `seccion_id` int(11) DEFAULT NULL,
+  `distrito_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/db-mysql/fiscales_db.sql
+++ b/db-mysql/fiscales_db.sql
@@ -11,31 +11,22 @@ SET time_zone = "+00:00";
 --
 -- Base de datos: `fiscales_db`
 --
-
--- --------------------------------------------------------
-
--- -------
--- Estado de los usuarios 
--- -------
+-- -----------------------
+-- Usuario
+-- -----------------------
 CREATE TABLE `gen_user_status` (
   `id` int(11) NOT NULL,
   `description` varchar(100) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- -------
--- Niveles de usuarios para seguridad (alternativa a Rol)
--- -------
 CREATE TABLE `gen_user_level` (
   `id` int(11) NOT NULL,
   `description` varchar(45) NOT NULL,
   `enabled` tinyint(4) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- -------
--- Usuarios, con firebaseId
--- -------
 CREATE TABLE `gen_user` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_name` varchar(100) NOT NULL,
@@ -60,24 +51,12 @@ CREATE TABLE `gen_user` (
   KEY `user_sttatus_idx` (`status_id`),
   CONSTRAINT `user_level` FOREIGN KEY (`level_id`) REFERENCES `gen_user_level` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   CONSTRAINT `user_status` FOREIGN KEY (`status_id`) REFERENCES `gen_user_status` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=MyISAM AUTO_INCREMENT=34 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- -------
--- Rol
--- -------
-CREATE TABLE `sec_rol` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `description` varchar(45) NOT NULL,
-  `create_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `create_user_id` int(11) NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `rol_user_idx` (`create_user_id`),
-  CONSTRAINT `rol_user` FOREIGN KEY (`create_user_id`) REFERENCES `gen_user` (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+-- -----------------------
+-- Seguridad
+-- -----------------------
 
--- -------
--- Privilegio
--- -------
 CREATE TABLE `sec_privilege` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `description` varchar(45) NOT NULL,
@@ -86,11 +65,18 @@ CREATE TABLE `sec_privilege` (
   PRIMARY KEY (`id`),
   KEY `privilege_user_idx` (`create_user_id`),
   CONSTRAINT `privilege_user` FOREIGN KEY (`create_user_id`) REFERENCES `gen_user` (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- -------
--- Rol Privilegio
--- -------
+CREATE TABLE `sec_rol` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `description` varchar(45) NOT NULL,
+  `create_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `create_user_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `rol_user_idx` (`create_user_id`),
+  CONSTRAINT `rol_user` FOREIGN KEY (`create_user_id`) REFERENCES `gen_user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE `sec_rol_privilege` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `rol_id` int(11) NOT NULL,
@@ -104,12 +90,10 @@ CREATE TABLE `sec_rol_privilege` (
   CONSTRAINT `rol_privilege_create_user` FOREIGN KEY (`create_user_id`) REFERENCES `gen_user` (`id`),
   CONSTRAINT `rol_privilege_privilege` FOREIGN KEY (`privilege_id`) REFERENCES `sec_privilege` (`id`),
   CONSTRAINT `rol_privilege_rol` FOREIGN KEY (`rol_id`) REFERENCES `sec_rol` (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
--- -------
--- Relacion usuario Rol
--- -------
+
 CREATE TABLE `gen_user_rol` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL,
@@ -123,8 +107,104 @@ CREATE TABLE `gen_user_rol` (
   CONSTRAINT `user_rol_create_user` FOREIGN KEY (`create_user_id`) REFERENCES `gen_user` (`id`),
   CONSTRAINT `user_rol_rol` FOREIGN KEY (`rol_id`) REFERENCES `sec_rol` (`id`),
   CONSTRAINT `user_rol_user` FOREIGN KEY (`user_id`) REFERENCES `gen_user` (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=28 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+
+-- -----------------------
+-- Estructura territorial
+-- -----------------------
+
+CREATE TABLE `gen_distrito` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `descripcion` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+  -- Existen distintos modelos entre provincias / BsAs,Mza,Tucuman / CABA en la seccion, pero unificamos todo en seccion para mantener la estructura estandar
+  -- -----------------------
+CREATE TABLE `gen_seccion` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `distrito_id` int(11) NOT NULL,
+  `descripcion` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `seccion_distrito_idx` (`distrito_id`),
+  CONSTRAINT `seccion_distrito` FOREIGN KEY (`distrito_id`) REFERENCES `gen_distrito` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `gen_circuito` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `seccion_id` int(11) NOT NULL,
+  `descripcion` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `circuito_seccion_idx` (`seccion_id`),
+  CONSTRAINT `circuito_seccion` FOREIGN KEY (`seccion_id`) REFERENCES `gen_seccion` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `gen_local_comicio` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `circuito_id` int(11) NOT NULL,
+  `descripcion` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `localcomicio_circuito_idx` (`circuito_id`),
+  CONSTRAINT `localcomicio_circuito` FOREIGN KEY (`circuito_id`) REFERENCES `gen_circuito` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `gen_mesa` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `local_comicio_id` int(11) NOT NULL,
+  `descripcion` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `mesa_localcomicio_idx` (`local_comicio_id`),
+  CONSTRAINT `mesa_localcomicio` FOREIGN KEY (`local_comicio_id`) REFERENCES `gen_local_comicio` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -----------------------
+-- Comicio
+-- -----------------------
+
+CREATE TABLE `com_comicio_estado` (
+  `id` INT NOT NULL,
+  `descripcion` VARCHAR(45) NULL,
+  PRIMARY KEY (`id`));
+
+CREATE TABLE `com_comicio` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `descripcion` varchar(100) NOT NULL,
+  `estado_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `comicio_comicioestado_idx` (`estado_id`),
+  CONSTRAINT `comicio_comicioestado` FOREIGN KEY (`estado_id`) REFERENCES `com_comicio_estado` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `com_comicio_categoria` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `comicio_id` int(11) NOT NULL,
+  `descripcion` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `comiciocategoria_comicio_idx` (`comicio_id`),
+  CONSTRAINT `comiciocategoria_comicio` FOREIGN KEY (`comicio_id`) REFERENCES `com_comicio` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `com_comicio_fuerza_politica` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `comicio_id` int(11) NOT NULL,
+  `descripcion` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `comiciofuerzapolitica_comicio_idx` (`comicio_id`),
+  CONSTRAINT `comiciofuerzapolitica_comicio` FOREIGN KEY (`comicio_id`) REFERENCES `com_comicio` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `com_comisio_candidato` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `comicio_categoria_id` int(11) NOT NULL,
+  `comicio_fuerza_politica_id` int(11) NOT NULL,
+  `descripcion` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `comiciocandidato_comiciofuerzapolitica_idx` (`comicio_fuerza_politica_id`),
+  KEY `comiciocandidato_comiciocategoria_idx` (`comicio_categoria_id`),
+  CONSTRAINT `comiciocandidato_comiciocategoria` FOREIGN KEY (`comicio_categoria_id`) REFERENCES `com_comicio_categoria` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `comiciocandidato_comiciofuerzapolitica` FOREIGN KEY (`comicio_fuerza_politica_id`) REFERENCES `com_comicio_fuerza_politica` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/db-mysql/fiscales_db.sql
+++ b/db-mysql/fiscales_db.sql
@@ -120,8 +120,8 @@ CREATE TABLE `gen_distrito` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-  -- Existen distintos modelos entre provincias / BsAs,Mza,Tucuman / CABA en la seccion, pero unificamos todo en seccion para mantener la estructura estandar
-  -- -----------------------
+	-- Existen distintos modelos entre provincias / BsAs,Mza,Tucuman / CABA en la seccion, pero unificamos todo en seccion para mantener la estructura estandar
+	-- -----------------------
 CREATE TABLE `gen_seccion` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `distrito_id` int(11) NOT NULL,
@@ -243,6 +243,71 @@ CREATE TABLE `fis_fiscal_coordinador` (
   CONSTRAINT `coordinador_seccion` FOREIGN KEY (`seccion_id`) REFERENCES `gen_seccion` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   CONSTRAINT `coordinador_user` FOREIGN KEY (`user_id`) REFERENCES `gen_user` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -----------------------
+-- fiscalizcion - centro computo
+-- -----------------------
+CREATE TABLE `fis_centro_computo` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `descripcion` varchar(100) NOT NULL,
+  `reponsable_user_id` int(11) NOT NULL,
+  `circuito_id` int(11) DEFAULT NULL,
+  `seccion_id` int(11) DEFAULT NULL,
+  `distrito_id` int(11) DEFAULT NULL,
+  `telefono_recepcion_imagen` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `centrocomputo_responsable_idx` (`reponsable_user_id`),
+  KEY `centrocomputo_circuito_idx` (`circuito_id`),
+  KEY `centrocomputo_seccion_idx` (`seccion_id`),
+  KEY `centrocomputo_distrito_idx` (`distrito_id`),
+  CONSTRAINT `centrocomputo_circuito` FOREIGN KEY (`circuito_id`) REFERENCES `gen_circuito` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `centrocomputo_distrito` FOREIGN KEY (`distrito_id`) REFERENCES `gen_distrito` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `centrocomputo_responsable` FOREIGN KEY (`reponsable_user_id`) REFERENCES `gen_user` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `centrocomputo_seccion` FOREIGN KEY (`seccion_id`) REFERENCES `gen_seccion` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `fis_centro_computo_auditor` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `centro_computo_id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `centrocomputoauditor_centrocomputo_idx` (`centro_computo_id`),
+  KEY `centrocomputoauditor_user_idx` (`user_id`),
+  CONSTRAINT `centrocomputoauditor_centrocomputo` FOREIGN KEY (`centro_computo_id`) REFERENCES `fis_centro_computo` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `centrocomputoauditor_user` FOREIGN KEY (`user_id`) REFERENCES `gen_user` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `fis_centro_computo_auditoria_acta_fiscal_estado` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `descripcion` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `fis_centro_computo_auditoria_acta_correo_estado` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `descripcion` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `fis_centro_computo_auditoria` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `createDate` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `auditor_id` int(11) NOT NULL,
+  `mesa_id` int(11) NOT NULL,
+  `acta_fiscal_estado_id` int(11) DEFAULT NULL,
+  `acta_correo_estado_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `centrocomputoauditoria_auditor_idx` (`auditor_id`),
+  KEY `centro_computo_auditoria_mesaid_idx` (`mesa_id`),
+  KEY `centrocomputoauditoria_estadoacta_idx` (`acta_fiscal_estado_id`),
+  KEY `centrocomputoauditoria_estadocorreoacta_idx` (`acta_correo_estado_id`),
+  CONSTRAINT `centrocomputoauditoria_auditor` FOREIGN KEY (`auditor_id`) REFERENCES `fis_centro_computo_auditor` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `centrocomputoauditoria_estadoacta` FOREIGN KEY (`acta_fiscal_estado_id`) REFERENCES `fis_centro_computo_auditoria_acta_fiscal_estado` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `centrocomputoauditoria_estadocorreoacta` FOREIGN KEY (`acta_correo_estado_id`) REFERENCES `fis_centro_computo_auditoria_acta_correo_estado` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `centrocomputoauditoria_mesaid` FOREIGN KEY (`mesa_id`) REFERENCES `gen_mesa` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;

--- a/db-mysql/fiscales_db.sql
+++ b/db-mysql/fiscales_db.sql
@@ -14,40 +14,118 @@ SET time_zone = "+00:00";
 
 -- --------------------------------------------------------
 
---
--- Estructura de tabla para la tabla `users`
---
-
-CREATE TABLE `users` (
-  `id` mediumint(8) UNSIGNED NOT NULL,
-  `username` varchar(64) NOT NULL,
-  `password` varchar(64) NOT NULL COMMENT 'MD5',
-  `role` tinyint(3) UNSIGNED NOT NULL DEFAULT 0,
-  `enabled` tinyint(1) NOT NULL DEFAULT 0,
-  `creation_stamp` timestamp NOT NULL DEFAULT current_timestamp(),
-  `update_stamp` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp()
+-- -------
+-- Estado de los usuarios 
+-- -------
+CREATE TABLE `gen_user_status` (
+  `id` int(11) NOT NULL,
+  `description` varchar(100) DEFAULT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
---
--- Índices para tablas volcadas
---
+-- -------
+-- Niveles de usuarios para seguridad (alternativa a Rol)
+-- -------
+CREATE TABLE `gen_user_level` (
+  `id` int(11) NOT NULL,
+  `description` varchar(45) NOT NULL,
+  `enabled` tinyint(4) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
---
--- Indices de la tabla `users`
---
-ALTER TABLE `users`
-  ADD PRIMARY KEY (`id`);
+-- -------
+-- Usuarios, con firebaseId
+-- -------
+CREATE TABLE `gen_user` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_name` varchar(100) NOT NULL,
+  `password` varchar(100) NOT NULL,
+  `firebase_uid` varchar(255) DEFAULT NULL,
+  `first_name` varchar(100) NOT NULL,
+  `last_name` varchar(100) NOT NULL,
+  `national_id` varchar(45) DEFAULT NULL,
+  `level_id` int(11) DEFAULT NULL,
+  `phone` varchar(45) DEFAULT NULL,
+  `contact_email` varchar(100) DEFAULT NULL,
+  `avatar` blob,
+  `enabled` tinyint(4) NOT NULL DEFAULT '1',
+  `create_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `create_user_id` int(11) NOT NULL,
+  `update_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `update_user_id` int(11) NOT NULL,
+  `status_id` int(11) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `email_UNIQUE` (`user_name`),
+  KEY `user_level_idx` (`level_id`),
+  KEY `user_sttatus_idx` (`status_id`),
+  CONSTRAINT `user_level` FOREIGN KEY (`level_id`) REFERENCES `gen_user_level` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `user_status` FOREIGN KEY (`status_id`) REFERENCES `gen_user_status` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=MyISAM AUTO_INCREMENT=34 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
---
--- AUTO_INCREMENT de las tablas volcadas
---
+-- -------
+-- Rol
+-- -------
+CREATE TABLE `sec_rol` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `description` varchar(45) NOT NULL,
+  `create_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `create_user_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `rol_user_idx` (`create_user_id`),
+  CONSTRAINT `rol_user` FOREIGN KEY (`create_user_id`) REFERENCES `gen_user` (`id`)
+) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
---
--- AUTO_INCREMENT de la tabla `users`
---
-ALTER TABLE `users`
-  MODIFY `id` mediumint(8) UNSIGNED NOT NULL AUTO_INCREMENT;
-COMMIT;
+-- -------
+-- Privilegio
+-- -------
+CREATE TABLE `sec_privilege` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `description` varchar(45) NOT NULL,
+  `create_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `create_user_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `privilege_user_idx` (`create_user_id`),
+  CONSTRAINT `privilege_user` FOREIGN KEY (`create_user_id`) REFERENCES `gen_user` (`id`)
+) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- -------
+-- Rol Privilegio
+-- -------
+CREATE TABLE `sec_rol_privilege` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `rol_id` int(11) NOT NULL,
+  `privilege_id` int(11) NOT NULL,
+  `create_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `create_user_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `Unique` (`rol_id`,`privilege_id`),
+  KEY `rol_privilege_privilege_idx` (`privilege_id`),
+  KEY `rol_privilege_create_user_idx` (`create_user_id`),
+  CONSTRAINT `rol_privilege_create_user` FOREIGN KEY (`create_user_id`) REFERENCES `gen_user` (`id`),
+  CONSTRAINT `rol_privilege_privilege` FOREIGN KEY (`privilege_id`) REFERENCES `sec_privilege` (`id`),
+  CONSTRAINT `rol_privilege_rol` FOREIGN KEY (`rol_id`) REFERENCES `sec_rol` (`id`)
+) ENGINE=MyISAM AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+
+-- -------
+-- Relacion usuario Rol
+-- -------
+CREATE TABLE `gen_user_rol` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `rol_id` int(11) NOT NULL,
+  `create_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `create_user_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `user_rol_user_idx` (`user_id`),
+  KEY `user_rol_rol_idx` (`rol_id`),
+  KEY `user_rol_create_user_idx` (`create_user_id`),
+  CONSTRAINT `user_rol_create_user` FOREIGN KEY (`create_user_id`) REFERENCES `gen_user` (`id`),
+  CONSTRAINT `user_rol_rol` FOREIGN KEY (`rol_id`) REFERENCES `sec_rol` (`id`),
+  CONSTRAINT `user_rol_user` FOREIGN KEY (`user_id`) REFERENCES `gen_user` (`id`)
+) ENGINE=MyISAM AUTO_INCREMENT=28 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;

--- a/db-mysql/fiscales_db.sql
+++ b/db-mysql/fiscales_db.sql
@@ -15,13 +15,13 @@ SET time_zone = "+00:00";
 -- Usuario
 -- -----------------------
 CREATE TABLE `gen_user_status` (
-  `id` int(11) NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `description` varchar(100) DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `gen_user_level` (
-  `id` int(11) NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `description` varchar(45) NOT NULL,
   `enabled` tinyint(4) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`)
@@ -158,60 +158,13 @@ CREATE TABLE `gen_mesa` (
   CONSTRAINT `mesa_localcomicio` FOREIGN KEY (`local_comicio_id`) REFERENCES `gen_local_comicio` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- -----------------------
--- Comicio
--- -----------------------
-/*
-CREATE TABLE `com_comicio_estado` (
-  `id` INT NOT NULL,
-  `descripcion` VARCHAR(45) NULL,
-  PRIMARY KEY (`id`));
 
-CREATE TABLE `com_comicio` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `descripcion` varchar(100) NOT NULL,
-  `estado_id` int(11) NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `comicio_comicioestado_idx` (`estado_id`),
-  CONSTRAINT `comicio_comicioestado` FOREIGN KEY (`estado_id`) REFERENCES `com_comicio_estado` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE `com_comicio_categoria` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `comicio_id` int(11) NOT NULL,
-  `descripcion` varchar(100) NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `comiciocategoria_comicio_idx` (`comicio_id`),
-  CONSTRAINT `comiciocategoria_comicio` FOREIGN KEY (`comicio_id`) REFERENCES `com_comicio` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE `com_comicio_fuerza_politica` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `comicio_id` int(11) NOT NULL,
-  `descripcion` varchar(100) NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `comiciofuerzapolitica_comicio_idx` (`comicio_id`),
-  CONSTRAINT `comiciofuerzapolitica_comicio` FOREIGN KEY (`comicio_id`) REFERENCES `com_comicio` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE `com_comisio_candidato` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `comicio_categoria_id` int(11) NOT NULL,
-  `comicio_fuerza_politica_id` int(11) NOT NULL,
-  `descripcion` varchar(100) NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `comiciocandidato_comiciofuerzapolitica_idx` (`comicio_fuerza_politica_id`),
-  KEY `comiciocandidato_comiciocategoria_idx` (`comicio_categoria_id`),
-  CONSTRAINT `comiciocandidato_comiciocategoria` FOREIGN KEY (`comicio_categoria_id`) REFERENCES `com_comicio_categoria` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
-  CONSTRAINT `comiciocandidato_comiciofuerzapolitica` FOREIGN KEY (`comicio_fuerza_politica_id`) REFERENCES `com_comicio_fuerza_politica` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-*/
 -- -----------------------
 -- fiscalizcion
 -- -----------------------
 
 CREATE TABLE `fis_fiscalizacion_estado` (
-  `id` int(11) NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `descripcion` varchar(100) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -234,6 +187,7 @@ CREATE TABLE `fis_fiscalizacion_mesa` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `fiscalizacion_id` int(11) NOT NULL,
   `mesa_id` int(11) NOT NULL,
+  `total_votantes` int(11) DEFAULT NULL,
   `votos_massarasa` int(11) DEFAULT NULL,
   `votos_milei` int(11) DEFAULT NULL,
   `votos_blanco` int(11) DEFAULT NULL,
@@ -249,6 +203,7 @@ CREATE TABLE `fis_fiscalizacion_mesa` (
   CONSTRAINT `fiscalizacionmesa_fiscalizacion` FOREIGN KEY (`fiscalizacion_id`) REFERENCES `fis_fiscalizacion` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   CONSTRAINT `fiscalizacionmesa_mesa` FOREIGN KEY (`mesa_id`) REFERENCES `gen_mesa` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 
 CREATE TABLE `fis_fiscal_mesa` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -272,16 +227,22 @@ CREATE TABLE `fis_fiscal_general` (
   CONSTRAINT `fiscalgeneral_user` FOREIGN KEY (`user_id`) REFERENCES `gen_user` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE `fis_coordinador` (
+CREATE TABLE `fis_fiscal_coordinador` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL,
   `circuito_id` int(11) DEFAULT NULL,
   `seccion_id` int(11) DEFAULT NULL,
   `distrito_id` int(11) DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `coordinador_idx` (`circuito_id`),
+  KEY `coordinador_seccion_idx` (`seccion_id`),
+  KEY `coordinador_distrito_idx` (`distrito_id`),
+  KEY `coordinador_user_idx` (`user_id`),
+  CONSTRAINT `coordinador_circuito` FOREIGN KEY (`circuito_id`) REFERENCES `gen_circuito` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `coordinador_distrito` FOREIGN KEY (`distrito_id`) REFERENCES `gen_distrito` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `coordinador_seccion` FOREIGN KEY (`seccion_id`) REFERENCES `gen_seccion` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `coordinador_user` FOREIGN KEY (`user_id`) REFERENCES `gen_user` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;

--- a/db-mysql/fiscales_db.sql
+++ b/db-mysql/fiscales_db.sql
@@ -310,6 +310,89 @@ CREATE TABLE `fis_centro_computo_auditoria` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
+-- -----------------------
+-- denuncia de fiscales o usuarios de la plataforma 
+-- -----------------------
+
+CREATE TABLE `den_denuncia_tipo` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `descripcion` varchar(45) DEFAULT NULL,
+  `nivel` int(11) NOT NULL DEFAULT '1' COMMENT 'refiere al nivel de importancia que debe darsele a la denuncia de este tipo',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `den_denuncia_estado` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `descripcion` varchar(45) NOT NULL,
+  `es_activa` tinyint(4) NOT NULL DEFAULT '1' COMMENT 'Define si el estado de la denuncia es activo o no, refiriendose a que ya no deberia listarse',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `den_denuncia_usuario` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `creacion_fecha` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `creacion_user_id` int(11) NOT NULL,
+  `mesa_id` int(11) DEFAULT NULL,
+  `local_comicio_id` int(11) DEFAULT NULL,
+  `tipo_id` int(11) NOT NULL,
+  `descripcion_usuario` varchar(5000) NOT NULL,
+  `imagen_url` varchar(200) DEFAULT NULL,
+  `estado_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `denuncia_usuariocreacion_idx` (`creacion_user_id`),
+  KEY `denuncia_mesa_idx` (`mesa_id`),
+  KEY `denuncia_localcomicio_idx` (`local_comicio_id`),
+  KEY `denuncia_tipodenuncia_idx` (`tipo_id`),
+  KEY `denuncia_estadodenuncia_idx` (`estado_id`),
+  CONSTRAINT `denuncia_estadodenuncia` FOREIGN KEY (`estado_id`) REFERENCES `den_denuncia_estado` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `denuncia_localcomicio` FOREIGN KEY (`local_comicio_id`) REFERENCES `gen_local_comicio` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `denuncia_mesa` FOREIGN KEY (`mesa_id`) REFERENCES `gen_mesa` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `denuncia_tipodenuncia` FOREIGN KEY (`tipo_id`) REFERENCES `den_denuncia_tipo` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `denuncia_usuariocreacion` FOREIGN KEY (`creacion_user_id`) REFERENCES `gen_user` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+-- -----------------------
+-- denuncia publicas
+-- -----------------------
+CREATE TABLE `den_denuncia_publica_tipo` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `descripcion` varchar(50) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+CREATE TABLE `den_denuncia_publica_estado` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `descripcion` varchar(50) DEFAULT NULL,
+  `es_activa` tinyint(4) DEFAULT '1' COMMENT 'refiere a si el estado debe listarse o no',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `den_denuncia_publica_dispositivo_bloqueado` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `dispositivo_id` varchar(100) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `den_denuncia_publica` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `creacion_fecha` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `codPostal` varchar(45) NOT NULL,
+  `tipo_id` int(11) DEFAULT NULL,
+  `titulo` varchar(100) NOT NULL,
+  `descripcion` varchar(5000) NOT NULL,
+  `contacto` varchar(200) DEFAULT NULL,
+  `dispositivo_origen_id` varchar(100) NOT NULL,
+  `estado_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `denunciapublica_tipo_idx` (`tipo_id`),
+  CONSTRAINT `denunciapublica_tipo` FOREIGN KEY (`tipo_id`) REFERENCES `den_denuncia_publica_tipo` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+
+
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;


### PR DESCRIPTION
Cree la estructura de centro de computo.
La idea es tener un centro de computo donde se le puedan asignar los distritos, secciones o circuito. Para que de esa manera se supervisen esas mesas,
consta de 
Centro computo --> agrupador principal
Centro de computo auditores --> La relación de usuarios y centro
Centro de computo auditorias --> la tabla con la relación entre el auditor y la mesa que audito, junto al estado del acta fiscal mas la del correo. para comprobar y chequear los dos al mismo momento.

De esta manera tenemos separado la fiscalizacion de la gente, que enviara su informacion, y la del centro de computo para el doble chequeo. de la misma manera que ahora las mesas pueden buscar su centro de computo para enviar las imágenes y para enviar denuncias.

Ademas esta el modulo de denuncias, tanto para interno como para  publico, con listado de dispositivos para banear a algunos boludos que quieran meter cosas al pedo