### PR TITLE
Removed default Vite font in index.css

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -60,18 +60,6 @@
   }
 }
 
-:root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
-}
-
 a {
   font-weight: 500;
   color: #646cff;


### PR DESCRIPTION
Se removió la linea que hacia que siempre se ponga Inter como fuente por defecto, lo cual hacia que nunca se muestre la fuente Poppins

Antes:
![CleanShot 2023-10-29 at 14 46 32@2x](https://github.com/Las-Fuerzas-Del-Cielo/Sistema-Anti-Fraude-Electoral/assets/15878526/114fe3c6-a0ac-4529-8aaa-551616b11df8)

Despues:
![CleanShot 2023-10-29 at 14 45 12@2x](https://github.com/Las-Fuerzas-Del-Cielo/Sistema-Anti-Fraude-Electoral/assets/15878526/9e46b92b-dadc-4963-bc7c-eeab8d5335cd)
